### PR TITLE
fixing MD5 with source instead of destination

### DIFF
--- a/utils/rule-merger.php
+++ b/utils/rule-merger.php
@@ -431,7 +431,7 @@ function updateRuleHash($rule, $method)
             $rule->services->getFastHashComp() . $rule->apps->getFastHashComp(), true);
     elseif( $method == 6)
         $rule->mergeHash = md5('action:'.$rule->action().'.*/' . $rule->to->getFastHashComp() .
-            $rule->destination->getFastHashComp() . $rule->destination->getFastHashComp() .
+            $rule->source->getFastHashComp() . $rule->destination->getFastHashComp() .
             $rule->services->getFastHashComp() . $rule->apps->getFastHashComp(), true);
     elseif( $method == 7)
         $rule->mergeHash = md5('action:'.$rule->action().'.*/' . $rule->to->getFastHashComp() .


### PR DESCRIPTION
Method 6 is matchToSrcDstSvcApp. Matching the right order on method 6